### PR TITLE
Fix init of member var in constructor, move constructor definition to…

### DIFF
--- a/jsonRW.hpp
+++ b/jsonRW.hpp
@@ -43,12 +43,12 @@ class jWrite
 {
   private:
 	// Variables:
-	char *buffer;		 // pointer to application's buffer
-	unsigned int buflen; // length of buffer
-	char *bufp;			 // current write position in buffer
-	char tmpbuf[32];	 // local buffer for int/double convertions
-	int error;			 // error code
-	int callNo;			 // API call on which error occurred
+	char *buffer;		// pointer to application's buffer
+	unsigned int buflen;	// length of buffer
+	char *bufp;		// current write position in buffer
+	char tmpbuf[32];	// local buffer for int/double convertions
+	int error;		// error code
+	int callNo;		// API call on which error occurred
 	struct jwNodeStack
 	{
 		enum JsonNodeType nodeType;
@@ -136,10 +136,7 @@ class jWrite
 	int _jwArr();
 
   public:
-	jWrite(char *pbuffer, int buf_len) : buffer(pbuffer), buflen(buf_len)
-	{
-		open(JsonNodeType::JS_OBJECT, JW_COMPACT);
-	};
+	jWrite(char *pbuffer, int buf_len);
 
 	/**
 	 * @brief open writing of JSON

--- a/source/jsonRW.cpp
+++ b/source/jsonRW.cpp
@@ -13,6 +13,10 @@
 #include <stdio.h>
 #include <string.h>
 
+jWrite::jWrite(char *pbuffer, int buf_len) : buffer(pbuffer), buflen(buf_len), bufp(buffer), error(JWRITE_OK),  callNo(0), stackpos(0),  isPretty(false)
+{
+}
+
 void jWrite::open(enum JsonNodeType rootType, int is_Pretty)
 {
 	memset(buffer, 0, buflen); // zap the whole destination buffer (all string terminators)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -40,6 +40,12 @@ int main(int argc, char *argv[])
 
     err = jw.close(); // close root object - done
 
-    printf("JSON: \n\r%s \n\r", buffer);
+    if( !err )
+    {
+    	printf("JSON: \n\r%s \n\r", buffer);
+    }else
+    {
+	printf("JSON Error: %s @pos: %d\n\r", jw.errorToString(err), jw.errorPos());
+    }
     return 0;
 }


### PR DESCRIPTION
… src file

Remove open from constructor body to allow an object to be created without wipe
out the buffer string, this is most for the read function that is going to be
combined in the class